### PR TITLE
fix: replace deprecated layout prop

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -7,7 +7,7 @@ type ImageWrapperProps = {
 const ImageWrapper = ({ src, alt }: ImageWrapperProps) => {
   return (
     <figure className="w-[350px] h-[350px] relative overflow-hidden rounded-xl">
-      <Image layout="fill" className="object-cover" src={src} alt={alt} />
+      <Image fill className="object-cover" src={src} alt={alt} />
     </figure>
   );
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ type ImageWrapperProps = {
 const ImageWrapper = ({ src, alt }: ImageWrapperProps) => {
   return (
     <figure className="w-[350px] h-[400px] md:w-[530px] md:h-[420px] relative overflow-hidden rounded-xl">
-      <Image layout="fill" className="object-cover" src={src} alt={alt} />
+      <Image fill className="object-cover" src={src} alt={alt} />
     </figure>
   );
 };


### PR DESCRIPTION
## Summary
- fix Image components to use `fill` instead of deprecated `layout="fill"`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c76774fa4832182d664eedd766740