### PR TITLE
Use Raleway font

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Raleway, a custom Google Font.
 
 ## Learn More
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { Raleway } from 'next/font/google';
 import Navbar from './ui/navbar';
 
-const inter = Raleway({ subsets: ['latin'] });
+const raleway = Raleway({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: 'Poi Ranch',
@@ -21,7 +21,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body className={raleway.className}>
         <Navbar />
         {children}
       </body>


### PR DESCRIPTION
## Summary
- replace Inter with Raleway in README
- rename layout font constant to match Raleway

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c78ef24d4832196c839742ba0b8fd